### PR TITLE
Update changelog to match released version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 # CHANGELOG
 
-## v1.0.0
+## v2.2.0
 
 * Initial public release


### PR DESCRIPTION
The first public release is version 2.2.0, not 1.0.0. Update the
changelog accordingly.