### PR TITLE
Remove jq from packages

### DIFF
--- a/manifests/role/ansible_master.pp
+++ b/manifests/role/ansible_master.pp
@@ -46,7 +46,6 @@ class openshift::role::ansible_master (
   ensure_packages([
     'ansible',
     'git',
-    'jq',
     'pyOpenSSL',
     'wget',
   ])


### PR DESCRIPTION
This change removes `jq` from the list of needed packages as it's nowhere used inside the module and produces another unnecessary dependency on the EPEL repository.