### PR TITLE
Enable custom stats by default in Ansible

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.2.2
+
+* Enable Ansible option "show_custom_stats" to always show statistics
+
 ## v2.2.1
 
 * Quote resource "NetworkManager" so it's a string

--- a/manifests/role/ansible_master.pp
+++ b/manifests/role/ansible_master.pp
@@ -60,12 +60,17 @@ class openshift::role::ansible_master (
   }
 
   create_resources('ini_setting', prefix({
-    'ssh-conn-pipelining' => {
+    'defaults-show-custom-stats' => {
+      section => 'defaults',
+      setting => 'show_custom_stats',
+      value   => 'True',
+    },
+    'ssh-conn-pipelining'        => {
       section => 'ssh_connection',
       setting => 'pipelining',
       value   => 'True',
     },
-    'ssh-conn-controlpath' => {
+    'ssh-conn-controlpath'       => {
       section => 'ssh_connection',
       setting => 'control_path',
       value   => '/tmp/ansible-ssh-%%h-%%p-%%r',


### PR DESCRIPTION
The Ansible module "set_stats"[1] allows setting per-host and global
statistics during a playbook run. The default callback plugin doesn't
show them unless explicitly enabled, though. Set the corresponding
option globally.

[1]
http://docs.testing.ansible.com/ansible/2.5/modules/set_stats_module.html