### PR TITLE
Add parameter to control ansible.cfg management

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v2.2.4
+
+* Add parameter to "openshift::role::ansible_master" class to control
+  management of Ansible configuration (not inventory).
+
 ## v2.2.3
 
 * Enable Ansible option "show_custom_stats" to always show statistics

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "appuio-openshift",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "author": "APPUiO",
   "summary": "Manages OpenShift Ansible and Playbooks",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
If another Puppet class manages Ansible's configuration there's little
use in if not negative effects from also managing individual settings
from the "openshift::role::ansible_master".