### PR TITLE
Accept Hash for group children

### DIFF
--- a/templates/ansible_hosts.erb
+++ b/templates/ansible_hosts.erb
@@ -8,7 +8,7 @@ groups = Marshal.load(Marshal.dump(@host_groups))
 
 groups.each_value do |group|
   # Convert children to hashes
-  if group and group.include?('children')
+  if group and group.include?('children') and group['children'].class == Array
     group['children'] = Hash[group['children'].product([{}])]
   end
 end


### PR DESCRIPTION
A valid Ansible inventory would contain a Hash in a groups children
value. So far we only used lists there and converted it to a hash. Now
we intend to do group nesting and the code faile due to product not
being a valid method on a hash. As there is nothing to do in this case,
one more test for type Array prevents the code from failing.